### PR TITLE
Document project fields and repository interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ VCS is intended to be licensed under the AGPL to ensure all improvements are giv
 
 * **Continuous Integration**: GitHub Actions lint and test both backend and frontend on every pull request.
 * **Deployment**: Successful builds publish a multi-service Docker image that serves the FastAPI backend and the static React frontend.
+
+## Project Management and Repository
+
+See [docs/project-management.md](docs/project-management.md) for details on project fields, repository import/export formats, and switching or sharing projects.

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -1,0 +1,19 @@
+# Project Management and Repository Interaction
+
+## Voice Project Fields
+- **Name**: Human-readable identifier for the project.
+- **Language**: Language code (e.g., `en-US`) indicating the voice's language.
+- **Engine Type**: Target synthesis engine such as Piper, RH Voice, or others.
+- **Metadata**: Additional details like description, author, license, or tags.
+
+## Repository Interaction
+Projects can be stored locally or synchronized with remote repositories.
+
+- **Import**: Load from a `.zip` archive or clone from a Git repository containing project files and metadata.
+- **Export**: Save as a `.zip` archive or push commits to a remote Git repository.
+- **Version Control**: Each project is tracked with Git, enabling branching and history for recordings, transcripts, and configuration.
+
+## Switching and Sharing Projects
+- The dashboard lists available projects; selecting a different entry switches context.
+- To share a project, export it as an archive or push to a shared repository so others can pull or clone it.
+- Importing shared archives or repositories adds them to the dashboard for further editing.


### PR DESCRIPTION
## Summary
- add project-management doc outlining voice project fields, repository import/export, and sharing workflows
- link new doc from README for quick discovery

## Testing
- `pre-commit run --files README.md docs/project-management.md` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest` *(no tests ran)*
- `npm test` *(missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890350168788324956d66e0c87d4466