### PR TITLE
Add audio processing and async job documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ VCS is intended to be licensed under the AGPL to ensure all improvements are giv
 
 * **Language/Framework**: Python with [FastAPI](https://fastapi.tiangolo.com/) provides an async REST API that can easily integrate with machine-learning libraries used for training and synthesis.
 * **Packaging**: [Poetry](https://python-poetry.org/) manages dependencies and virtual environments.
+* **Audio Cleanup**: [noisereduce](https://github.com/timsainb/noisereduce) removes background noise and [pydub](https://github.com/jiaaro/pydub) handles normalization.
+* **Transcription**: [OpenAI Whisper](https://openai.com/research/whisper) (medium model) produces transcripts stored as editable JSON with word-level timestamps.
+* **Asynchronous Jobs**: [Celery](https://docs.celeryq.dev/) with Redis runs background tasks and streams progress updates to clients via WebSockets (see [docs/asynchronous-jobs.md](docs/asynchronous-jobs.md)).
 
 ### Frontend
 

--- a/docs/asynchronous-jobs.md
+++ b/docs/asynchronous-jobs.md
@@ -1,0 +1,16 @@
+# Asynchronous Job Handling and Progress Feedback
+
+Voice Creator Studio offloads long-running tasks such as audio cleanup, transcription, and model training to background workers.
+
+## Architecture
+- **Task Queue**: [Celery](https://docs.celeryq.dev/) orchestrates jobs using Redis as both broker and results backend.
+- **Job IDs**: Each request that launches a background task returns a unique ID so clients can query progress.
+
+## Progress Updates
+- Workers periodically update task state in Redis with percentage complete and status messages.
+- The FastAPI backend exposes a `/progress/{job_id}` endpoint and a WebSocket channel that stream these updates to the frontend.
+- The React UI shows a progress bar and log snippets based on the streamed data.
+
+## Failure Handling
+- Failed tasks report error details through the same progress endpoint.
+- Users can retry or cancel jobs from the interface if a task fails or stalls.


### PR DESCRIPTION
## Summary
- note chosen libraries for audio cleanup and transcription in README
- document asynchronous Celery/Redis workflow and progress feedback

## Testing
- `pre-commit run --files README.md docs/asynchronous-jobs.md` *(fails: `.pre-commit-config.yaml` is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68903c0d831c8324967e4d04af912d4d