### PR TITLE
Document training data formats and job management

### DIFF
--- a/docs/asynchronous-jobs.md
+++ b/docs/asynchronous-jobs.md
@@ -6,6 +6,10 @@ Voice Creator Studio offloads long-running tasks such as audio cleanup, transcri
 - **Task Queue**: [Celery](https://docs.celeryq.dev/) orchestrates jobs using Redis as both broker and results backend.
 - **Job IDs**: Each request that launches a background task returns a unique ID so clients can query progress.
 
+## Job Scheduling and Resource Management
+- Celery routes work to CPU-only or GPU-enabled queues based on task requirements.
+- Worker concurrency is capped to match available hardware, preventing oversubscription and balancing throughput.
+
 ## Progress Updates
 - Workers periodically update task state in Redis with percentage complete and status messages.
 - The FastAPI backend exposes a `/progress/{job_id}` endpoint and a WebSocket channel that stream these updates to the frontend.
@@ -14,3 +18,8 @@ Voice Creator Studio offloads long-running tasks such as audio cleanup, transcri
 ## Failure Handling
 - Failed tasks report error details through the same progress endpoint.
 - Users can retry or cancel jobs from the interface if a task fails or stalls.
+
+## Monitoring, Pausing, and Resuming
+- The `/progress/{job_id}` endpoint and WebSocket stream provide live updates so users can monitor jobs.
+- Canceling a job stops execution but retains intermediate checkpoints on disk.
+- Resuming queues a new task that loads those checkpoints and continues training from the last saved state.


### PR DESCRIPTION
## Summary
- outline preprocessing conventions for neural, HMM-based, concatenative, and singing engines
- describe Celery/Redis scheduling and resource allocation
- document monitoring controls for progress endpoints, cancellation, and resume

## Testing
- `pre-commit run --files README.md docs/asynchronous-jobs.md -v` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_689043bdd6c883248a7b8d30fa85cfc0